### PR TITLE
Fixed disabled widgets in frame after page switch

### DIFF
--- a/ui/src/virtualconsole/vcframe.cpp
+++ b/ui/src/virtualconsole/vcframe.cpp
@@ -117,6 +117,8 @@ void VCFrame::setDisableState(bool disable)
     foreach (VCWidget* widget, this->findChildren<VCWidget*>())
         widget->setDisableState(disable);
     m_disableState = disable;
+    if (!disable)
+        setEnabled(!disable);
     updateFeedback();
     //VCWidget::setDisableState(disable);
 }


### PR DESCRIPTION
Had to call setEnabled() on the frame itself to make it work, but only when activating.
There is still an issue present that the disable state of a frame in a multipaged frame is not saved. But this is not so easy to implement with the current architecture.
Fixes: http://www.qlcplus.org/forum/viewtopic.php?f=33&p=46258#p46258